### PR TITLE
Fix \d fails with "column c.relhasoids does not exist" in postgresql 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.7.0-slim
 MAINTAINER Dennis Coldwell <dennis.coldwell@gmail.com>
 RUN apt-get -y update && apt-get -y install libpq-dev build-essential less
 RUN pip install pgcli
+RUN pip install pgspecial
 ADD run-pgcli.sh /bin/run-pgcli.sh
 ENV PAGER=less
 ENTRYPOINT ["run-pgcli.sh"]


### PR DESCRIPTION
It makes \d happy.
See here for refs: https://github.com/dbcli/pgcli/issues/1130